### PR TITLE
Add support for formUrlEncoded

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rest-api-support",
-  "version": "2.0.0-beta.7",
+  "version": "2.0.0-beta.8",
   "description": "URL manipulation and other support infrastructure for making REST api calls",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/parameters.ts
+++ b/src/parameters.ts
@@ -61,6 +61,47 @@ class ParameterBuilder {
     return this;
   }
 
+  /**
+   * Send a form URL encoded body
+   *
+   * @param {object} data The key-value pairs to be encoded as form data
+   */
+  formUrlEncoded(data: { [key: string]: string | number | boolean | string[] }) {
+    const p = this.parameters;
+    p.headers = p.headers || {};
+    p.headers['content-type'] = 'application/x-www-form-urlencoded';
+
+    // Use URLSearchParams for standard-compliant encoding
+    const params = new URLSearchParams();
+
+    // Append each key-value pair, handling arrays
+    Object.entries(data).forEach(([key, value]) => {
+      if (Array.isArray(value)) {
+        // Handle arrays by adding multiple entries with the same key
+        value.forEach((item) => params.append(key, String(item)));
+      } else {
+        params.append(key, String(value));
+      }
+    });
+
+    p.body = params.toString();
+    return this;
+  }
+
+  /**
+   * Adds form data entries to a multipart/form-data request
+   *
+   * @param {string} name The field name to use in the form data
+   * @param {string|number|boolean|Buffer|Blob|File|Array} value The field value(s) to send
+   *        - Primitive values (string, number, boolean) will be converted to strings
+   *        - Buffer objects are sent as binary data
+   *        - Blob or File objects are sent directly
+   *        - Arrays can contain any of the above types and create multiple entries
+   * @param {FormDataOption|Array<FormDataOption>} options Optional metadata for the form data
+   *        - filename: Sets the filename for a file upload (e.g., "image.jpg")
+   *        - contentType: Sets the content type for the data (e.g., "image/jpeg")
+   *        - For arrays, you can provide a single options object or an array of options
+   */
   formData(
     name: string,
     value: string | number | boolean | Buffer | Blob | File | Array<string | Buffer | Blob | File>,


### PR DESCRIPTION
This pull request includes several changes to the `parameters.spec.ts` test file, the `parameters.ts` source file, and the `package.json` file. The main focus of the changes is to add support for form URL encoded parameters and to clean up some test code.

### Enhancements to form URL encoded parameters:

* [`src/parameters.ts`](diffhunk://#diff-ea382f4416303e3eaa9d71d5b2dee2096effa5e19e81252f349f2fa2d625879dR64-R104): Added a new method `formUrlEncoded` to the `ParameterBuilder` class to support sending form URL encoded bodies. This method handles key-value pairs, arrays, and special characters.

### Test improvements:

* [`__tests__/parameters.spec.ts`](diffhunk://#diff-ad28def266fe1817e53590fd0718bc06a80be878b35474f9babc8aca18147536R207-R276): Added a new test case `test('formUrlEncoded parameters', () => {` to verify the functionality of the `formUrlEncoded` method. This includes tests for simple key-value pairs, arrays, special characters, and empty values.
* [`__tests__/parameters.spec.ts`](diffhunk://#diff-ad28def266fe1817e53590fd0718bc06a80be878b35474f9babc8aca18147536L12-R13): Cleaned up existing test cases by removing unnecessary comments indicating undefined values. [[1]](diffhunk://#diff-ad28def266fe1817e53590fd0718bc06a80be878b35474f9babc8aca18147536L12-R13) [[2]](diffhunk://#diff-ad28def266fe1817e53590fd0718bc06a80be878b35474f9babc8aca18147536L47-R47)

### Version update:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the version from `2.0.0-beta.7` to `2.0.0-beta.8` to reflect the new changes.